### PR TITLE
Update TemplatedPlugin import for Shoop 3.0

### DIFF
--- a/shoop_carousel/plugins.py
+++ b/shoop_carousel/plugins.py
@@ -8,7 +8,10 @@
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from shoop.xtheme.plugins import TemplatedPlugin
+try:
+    from shoop.xtheme import TemplatedPlugin
+except ImportError:  # before Shoop 3.0
+    from shoop.xtheme.plugins import TemplatedPlugin
 from shoop.xtheme.resources import add_resource
 
 from shoop_carousel.models import Carousel


### PR DESCRIPTION
In Shoop 3.0 TemplatedPlugin is moved to shoop.xtheme from
shoop.xtheme.plugins.

Refs SHOOP-1955